### PR TITLE
Add proxy_socket_keepalive on;

### DIFF
--- a/hub.fastgit.org.conf
+++ b/hub.fastgit.org.conf
@@ -62,6 +62,7 @@ server
         proxy_http_version 1.1;
         proxy_connect_timeout 4s;
         proxy_read_timeout 4s;
+        proxy_socket_keepalive on;
 
         sub_filter "\"https://raw.githubusercontent.com" "\"https://raw.fastgit.org";
         sub_filter "\"https://github.com" "\"https://hub.fastgit.org";


### PR DESCRIPTION
如果已经在更上层的地方加了就close吧。

另外能说说为什么要`proxy_set_header Connection "";`吗

还有，https://doc.fastgit.org/zh-cn/node.html 里的两个“表列”应该是“列表”吧？

githubassets的.js和.css可以设置永不过期，因为GitHub引用它们的时候加了随机字符串，如果更新会直接用不同的文件。