### PR TITLE
TLS related work

### DIFF
--- a/hub.fastgit.org.conf
+++ b/hub.fastgit.org.conf
@@ -2,16 +2,17 @@ upstream github {
     server github.com:443;
     keepalive 32;
 }
-server
-{
-    listen 80;
+
+server {
+    listen 80 default_server;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
     listen 443 ssl http2;
     server_name hub.fastgit.org;
     root /www/wwwroot/hub.fastgit.org;
-    
-    if ($server_port !~ 443){
-        rewrite ^(/.*)$ https://$host$1 permanent;
-    }
 
     ssl_stapling on;
     ssl_stapling_verify on;

--- a/hub.fastgit.org.conf
+++ b/hub.fastgit.org.conf
@@ -21,6 +21,9 @@ server {
     ssl_certificate /www/server/panel/vhost/cert/hub.fastgit.org/fullchain.pem;
     ssl_certificate_key /www/server/panel/vhost/cert/hub.fastgit.org/privkey.pem;
 
+    # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /var/lib/nginx/dhparam.pem
+    ssl_dhparam /var/lib/nginx/dhparam.pem;
+
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;

--- a/hub.fastgit.org.conf
+++ b/hub.fastgit.org.conf
@@ -26,7 +26,7 @@ server
 
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 60m;
-    ssl_session_tickets on;
+    ssl_session_tickets off;
 
     error_page 497  https://$host$request_uri;
 

--- a/hub.fastgit.org.conf
+++ b/hub.fastgit.org.conf
@@ -21,6 +21,7 @@ server {
     ssl_certificate /www/server/panel/vhost/cert/hub.fastgit.org/fullchain.pem;
     ssl_certificate_key /www/server/panel/vhost/cert/hub.fastgit.org/privkey.pem;
 
+    # Run following command & set permission before configuring
     # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /var/lib/nginx/dhparam.pem
     ssl_dhparam /var/lib/nginx/dhparam.pem;
 


### PR DESCRIPTION
0. 改进了 HTTP 站重定向 HTTPS 站的配置
1. 禁用 TLS tickets 特性，0-RTT 对本项目意义不大，反而引入安全隐患
2. 针对 DHE 密钥交换的相关优化（使用 RFC 7919 文档中建议的循环群）——注意将该修改同步回服务器前，需要先执行注释里的命令，并设置好文件权限（举例如 `chown -R www-data:www-data /var/lib/nginx` 和 `chmod` 这一套操作）