### PR TITLE
Update download.fastgit.org.conf

### DIFF
--- a/download.fastgit.org.conf
+++ b/download.fastgit.org.conf
@@ -39,7 +39,7 @@ server {
 
     }
     
-    location ~ ^/[^/]+/[^/]+/releases/download/ {
+    location ~ ^/[^/]+/[^/]+/releases(/latest)?/download/ {
         proxy_cache_valid 206 120m;
         proxy_cache_valid 200 120m;
         recursive_error_pages on;


### PR DESCRIPTION
Support proxying URI like `/BurntSushi/ripgrep/releases/latest/download/ripgrep_12.1.1_amd64.deb`
Have been tested against https://regex.datahoarder.dev/regextester.php , should not break anything.