### PR TITLE
Update hub.fastgit.org.conf

### DIFF
--- a/hub.fastgit.org.conf
+++ b/hub.fastgit.org.conf
@@ -96,7 +96,9 @@ server {
         
         # Not supported when installed from Debian source
         # proxy_socket_keepalive on;
-
+        
+        proxy_ssl_server_name on;
+        
         sub_filter "\"https://raw.githubusercontent.com" "\"https://raw.fastgit.org";
         sub_filter "\"https://github.com" "\"https://hub.fastgit.org";
         sub_filter "\"https://github.githubassets.com" "\"https://assets.fastgit.org";


### PR DESCRIPTION
做其他反代站的时候也碰到502了…听你们说是ssl问题，我的那个站看了错误日志也是ssl问题，顺手修了下，不知道是否和fastgit那个登录一样…我的errorlog是：peer closed connection in SSL handshake while SSL handshaking to upstream
如果相同errorlog本次pr应该能解决问题